### PR TITLE
Prevent downstream dependencies to pickup MinVer as a depencency

### DIFF
--- a/projects/Directory.Packages.props
+++ b/projects/Directory.Packages.props
@@ -42,6 +42,6 @@
   <ItemGroup Condition="'$(IsPackable)'=='true'">
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <GlobalPackageReference Include="MinVer" Version="6.0.0" />
+    <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Proposed Changes

MinVer is beeing picked up by downstream dependencies which it shouldn't, see https://github.com/adamralph/minver/blob/main/README.md?plain=1#L55 .

This even breaks compatibility of the package with NonSDK projects.

https://www.nuget.org/packages/RabbitMQ.Client.OAuth2 was already published with this dependency.

As I didn't change any code I didn't run the tests.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories